### PR TITLE
添加了cobar对utf8mb4的支持

### DIFF
--- a/server/src/main/net/com/alibaba/cobar/net/FrontendConnection.java
+++ b/server/src/main/net/com/alibaba/cobar/net/FrontendConnection.java
@@ -50,8 +50,12 @@ public abstract class FrontendConnection extends AbstractConnection {
     protected int port;
     protected int localPort;
     protected long idleTimeout;
+
+    // 原则: 在数据库charset方面传输使用时，都是作为dbCharset来处理的，但是dbCharset来java内部的编码处理时需要转换成为对应的charseet
+    protected String dbCharset;
     protected String charset;
     protected int charsetIndex;
+
     protected byte[] seed;
     protected String user;
     protected String schema;
@@ -174,9 +178,10 @@ public abstract class FrontendConnection extends AbstractConnection {
     }
 
     public boolean setCharsetIndex(int ci) {
-        String charset = CharsetUtil.getCharset(ci);
+        String charset = CharsetUtil.getDbCharset(ci);
         if (charset != null) {
-            this.charset = charset;
+            this.dbCharset = charset;
+            this.charset = CharsetUtil.getCharset(ci);
             this.charsetIndex = ci;
             return true;
         } else {
@@ -189,9 +194,10 @@ public abstract class FrontendConnection extends AbstractConnection {
     }
 
     public boolean setCharset(String charset) {
-        int ci = CharsetUtil.getIndex(charset);
+        int ci = CharsetUtil.getDBIndex(charset);
         if (ci > 0) {
-            this.charset = charset;
+            this.charset = CharsetUtil.getCharset(ci);
+            this.dbCharset = charset;
             this.charsetIndex = ci;
             return true;
         } else {
@@ -252,6 +258,7 @@ public abstract class FrontendConnection extends AbstractConnection {
             mm.position(5);
             String sql = null;
             try {
+                // 使用指定的编码来读取数据
                 sql = mm.readString(charset);
             } catch (UnsupportedEncodingException e) {
                 writeErrMessage(ErrorCode.ER_UNKNOWN_CHARACTER_SET, "Unknown charset '" + charset + "'");

--- a/server/src/main/net/com/alibaba/cobar/net/FrontendConnection.java
+++ b/server/src/main/net/com/alibaba/cobar/net/FrontendConnection.java
@@ -51,7 +51,7 @@ public abstract class FrontendConnection extends AbstractConnection {
     protected int localPort;
     protected long idleTimeout;
 
-    // 原则: 在数据库charset方面传输使用时，都是作为dbCharset来处理的，但是dbCharset来java内部的编码处理时需要转换成为对应的charseet
+    // 原则: 数据库编码控制使用dbCharset来处理的，设计到Java相关的字符串编码解码采用charset来表示
     protected String dbCharset;
     protected String charset;
     protected int charsetIndex;

--- a/server/src/main/server/com/alibaba/cobar/heartbeat/CobarDetectorAuthenticator.java
+++ b/server/src/main/server/com/alibaba/cobar/heartbeat/CobarDetectorAuthenticator.java
@@ -44,7 +44,7 @@ public class CobarDetectorAuthenticator implements NIOHandler {
 
             // 设置字符集编码
             int charsetIndex = (hsp.serverCharsetIndex & 0xff);
-            String charset = CharsetUtil.getCharset(charsetIndex);
+            String charset = CharsetUtil.getDbCharset(charsetIndex);
             if (charset != null) {
                 source.setCharsetIndex(charsetIndex);
             } else {

--- a/server/src/main/server/com/alibaba/cobar/heartbeat/MySQLDetectorAuthenticator.java
+++ b/server/src/main/server/com/alibaba/cobar/heartbeat/MySQLDetectorAuthenticator.java
@@ -47,7 +47,7 @@ public class MySQLDetectorAuthenticator implements NIOHandler {
 
             // 设置字符集编码
             int charsetIndex = (hsp.serverCharsetIndex & 0xff);
-            String charset = CharsetUtil.getCharset(charsetIndex);
+            String charset = CharsetUtil.getDbCharset(charsetIndex);
             if (charset != null) {
                 source.setCharsetIndex(charsetIndex);
             } else {

--- a/server/src/main/server/com/alibaba/cobar/mysql/CharsetUtil.java
+++ b/server/src/main/server/com/alibaba/cobar/mysql/CharsetUtil.java
@@ -23,9 +23,17 @@ import java.util.Map;
  */
 public class CharsetUtil {
     private static final String[] INDEX_TO_CHARSET = new String[99];
+    private static final String[] INDEX_TO_DB_CHARSET = new String[99];
     private static final Map<String, Integer> CHARSET_TO_INDEX = new HashMap<String, Integer>();
+    private static final Map<String, Integer> DB_CHARSET_TO_INDEX = new HashMap<String, Integer>();
+
+    public static final String UTF8_MB4 = "utf8mb4";
+    public static final String UTF8 = "utf8";
+
     static {
         // index --> charset
+        // http://dev.mysql.com/doc/internals/en/character-set.html#packet-Protocol::CharacterSet
+        // SELECT id, collation_name FROM information_schema.collations ORDER BY id;
         INDEX_TO_CHARSET[1] = "big5";
         INDEX_TO_CHARSET[2] = "czech";
         INDEX_TO_CHARSET[3] = "dec8";
@@ -118,16 +126,118 @@ public class CharsetUtil {
         INDEX_TO_CHARSET[97] = "eucjpms";
         INDEX_TO_CHARSET[98] = "eucjpms";
 
+        INDEX_TO_DB_CHARSET[1] = "big5";
+        INDEX_TO_DB_CHARSET[2] = "czech";
+        INDEX_TO_DB_CHARSET[3] = "dec8";
+        INDEX_TO_DB_CHARSET[4] = "dos";
+        INDEX_TO_DB_CHARSET[5] = "german1";
+        INDEX_TO_DB_CHARSET[6] = "hp8";
+        INDEX_TO_DB_CHARSET[7] = "koi8_ru";
+        INDEX_TO_DB_CHARSET[8] = "latin1";
+        INDEX_TO_DB_CHARSET[9] = "latin2";
+        INDEX_TO_DB_CHARSET[10] = "swe7";
+        INDEX_TO_DB_CHARSET[11] = "usa7";
+        INDEX_TO_DB_CHARSET[12] = "ujis";
+        INDEX_TO_DB_CHARSET[13] = "sjis";
+        INDEX_TO_DB_CHARSET[14] = "cp1251";
+        INDEX_TO_DB_CHARSET[15] = "danish";
+        INDEX_TO_DB_CHARSET[16] = "hebrew";
+        INDEX_TO_DB_CHARSET[18] = "tis620";
+        INDEX_TO_DB_CHARSET[19] = "euc_kr";
+        INDEX_TO_DB_CHARSET[20] = "estonia";
+        INDEX_TO_DB_CHARSET[21] = "hungarian";
+        INDEX_TO_DB_CHARSET[22] = "koi8_ukr";
+        INDEX_TO_DB_CHARSET[23] = "win1251ukr";
+        INDEX_TO_DB_CHARSET[24] = "gb2312";
+        INDEX_TO_DB_CHARSET[25] = "greek";
+        INDEX_TO_DB_CHARSET[26] = "win1250";
+        INDEX_TO_DB_CHARSET[27] = "croat";
+        INDEX_TO_DB_CHARSET[28] = "gbk";
+        INDEX_TO_DB_CHARSET[29] = "cp1257";
+        INDEX_TO_DB_CHARSET[30] = "latin5";
+        INDEX_TO_DB_CHARSET[31] = "latin1_de";
+        INDEX_TO_DB_CHARSET[32] = "armscii8";
+        INDEX_TO_DB_CHARSET[33] = "utf8";
+        INDEX_TO_DB_CHARSET[34] = "win1250ch";
+        INDEX_TO_DB_CHARSET[35] = "ucs2";
+        INDEX_TO_DB_CHARSET[36] = "cp866";
+        INDEX_TO_DB_CHARSET[37] = "keybcs2";
+        INDEX_TO_DB_CHARSET[38] = "macce";
+        INDEX_TO_DB_CHARSET[39] = "macroman";
+        INDEX_TO_DB_CHARSET[40] = "pclatin2";
+        INDEX_TO_DB_CHARSET[41] = "latvian";
+        INDEX_TO_DB_CHARSET[42] = "latvian1";
+        INDEX_TO_DB_CHARSET[43] = "maccebin";
+        INDEX_TO_DB_CHARSET[44] = "macceciai";
+        INDEX_TO_DB_CHARSET[45] = "utf8mb4";
+        INDEX_TO_DB_CHARSET[46] = "";
+        INDEX_TO_DB_CHARSET[47] = "latin1bin";
+        INDEX_TO_DB_CHARSET[48] = "latin1cias";
+        INDEX_TO_DB_CHARSET[49] = "latin1csas";
+        INDEX_TO_DB_CHARSET[50] = "cp1251bin";
+        INDEX_TO_DB_CHARSET[51] = "cp1251cias";
+        INDEX_TO_DB_CHARSET[52] = "cp1251csas";
+        INDEX_TO_DB_CHARSET[53] = "macromanbin";
+        INDEX_TO_DB_CHARSET[54] = "macromancias";
+        INDEX_TO_DB_CHARSET[55] = "macromanciai";
+        INDEX_TO_DB_CHARSET[56] = "macromancsas";
+        INDEX_TO_DB_CHARSET[57] = "cp1256";
+        INDEX_TO_DB_CHARSET[63] = "binary";
+        INDEX_TO_DB_CHARSET[64] = "armscii";
+        INDEX_TO_DB_CHARSET[65] = "ascii";
+        INDEX_TO_DB_CHARSET[66] = "cp1250";
+        INDEX_TO_DB_CHARSET[67] = "cp1256";
+        INDEX_TO_DB_CHARSET[68] = "cp866";
+        INDEX_TO_DB_CHARSET[69] = "dec8";
+        INDEX_TO_DB_CHARSET[70] = "greek";
+        INDEX_TO_DB_CHARSET[71] = "hebrew";
+        INDEX_TO_DB_CHARSET[72] = "hp8";
+        INDEX_TO_DB_CHARSET[73] = "keybcs2";
+        INDEX_TO_DB_CHARSET[74] = "koi8r";
+        INDEX_TO_DB_CHARSET[75] = "koi8ukr";
+        INDEX_TO_DB_CHARSET[77] = "latin2";
+        INDEX_TO_DB_CHARSET[78] = "latin5";
+        INDEX_TO_DB_CHARSET[79] = "latin7";
+        INDEX_TO_DB_CHARSET[80] = "cp850";
+        INDEX_TO_DB_CHARSET[81] = "cp852";
+        INDEX_TO_DB_CHARSET[82] = "swe7";
+        INDEX_TO_DB_CHARSET[83] = "utf8";
+        INDEX_TO_DB_CHARSET[84] = "big5";
+        INDEX_TO_DB_CHARSET[85] = "euckr";
+        INDEX_TO_DB_CHARSET[86] = "gb2312";
+        INDEX_TO_DB_CHARSET[87] = "gbk";
+        INDEX_TO_DB_CHARSET[88] = "sjis";
+        INDEX_TO_DB_CHARSET[89] = "tis620";
+        INDEX_TO_DB_CHARSET[90] = "ucs2";
+        INDEX_TO_DB_CHARSET[91] = "ujis";
+        INDEX_TO_DB_CHARSET[92] = "geostd8";
+        INDEX_TO_DB_CHARSET[93] = "geostd8";
+        INDEX_TO_DB_CHARSET[94] = "latin1";
+        INDEX_TO_DB_CHARSET[95] = "cp932";
+        INDEX_TO_DB_CHARSET[96] = "cp932";
+        INDEX_TO_DB_CHARSET[97] = "eucjpms";
+        INDEX_TO_DB_CHARSET[98] = "eucjpms";
+
         // charset --> index
         for (int i = 0; i < INDEX_TO_CHARSET.length; i++) {
             String charset = INDEX_TO_CHARSET[i];
             if (charset != null && CHARSET_TO_INDEX.get(charset) == null) {
                 CHARSET_TO_INDEX.put(charset, i);
             }
+
+
+            charset = INDEX_TO_DB_CHARSET[i];
+            if (charset != null && DB_CHARSET_TO_INDEX.get(charset) == null) {
+                DB_CHARSET_TO_INDEX.put(charset, i);
+            }
         }
         CHARSET_TO_INDEX.put("iso-8859-1", 14);
         CHARSET_TO_INDEX.put("iso_8859_1", 14);
         CHARSET_TO_INDEX.put("utf-8", 33);
+
+        DB_CHARSET_TO_INDEX.put("iso-8859-1", 14);
+        DB_CHARSET_TO_INDEX.put("iso_8859_1", 14);
+        DB_CHARSET_TO_INDEX.put("utf-8", 33);
     }
 
     public static final String getCharset(int index) {
@@ -142,6 +252,22 @@ public class CharsetUtil {
             return 0;
         } else {
             Integer i = CHARSET_TO_INDEX.get(charset.toLowerCase());
+            return (i == null) ? 0 : i.intValue();
+        }
+    }
+
+    public static final String getDbCharset(int index) {
+        if (index < 0 || index > 98) {
+            index = 83;
+        }
+        return INDEX_TO_DB_CHARSET[index];
+    }
+
+    public static final int getDBIndex(String charset) {
+        if (charset == null || charset.length() == 0) {
+            return 0;
+        } else {
+            Integer i = DB_CHARSET_TO_INDEX.get(charset.toLowerCase());
             return (i == null) ? 0 : i.intValue();
         }
     }

--- a/server/src/main/server/com/alibaba/cobar/mysql/nio/MySQLConnection.java
+++ b/server/src/main/server/com/alibaba/cobar/mysql/nio/MySQLConnection.java
@@ -110,8 +110,11 @@ public class MySQLConnection extends BackendConnection {
     private MySQLConnectionPool pool;
     private long threadId;
     private HandshakePacket handshake;
+
     private int charsetIndex;
     private String charset;
+    private String dbCharset;
+
     private volatile int txIsolation;
     private volatile boolean autocommit;
     private long clientFlags;
@@ -500,4 +503,11 @@ public class MySQLConnection extends BackendConnection {
         return SecurityUtil.scramble411(passwd, seed);
     }
 
+    public String getDbCharset() {
+        return dbCharset;
+    }
+
+    public void setDbCharset(String dbCharset) {
+        this.dbCharset = dbCharset;
+    }
 }

--- a/server/src/main/server/com/alibaba/cobar/mysql/nio/MySQLConnectionAuthenticator.java
+++ b/server/src/main/server/com/alibaba/cobar/mysql/nio/MySQLConnectionAuthenticator.java
@@ -25,6 +25,7 @@ import com.alibaba.cobar.net.mysql.HandshakePacket;
 import com.alibaba.cobar.net.mysql.OkPacket;
 import com.alibaba.cobar.net.mysql.Reply323Packet;
 
+
 /**
  * MySQL 验证处理器
  * 
@@ -54,10 +55,12 @@ public class MySQLConnectionAuthenticator implements NIOHandler {
 
                 // 设置字符集编码
                 int charsetIndex = (packet.serverCharsetIndex & 0xff);
-                String charset = CharsetUtil.getCharset(charsetIndex);
+                String charset = CharsetUtil.getDbCharset(charsetIndex);
                 if (charset != null) {
                     source.setCharsetIndex(charsetIndex);
-                    source.setCharset(charset);
+                    source.setCharset(CharsetUtil.getCharset(charsetIndex));
+                    source.setDbCharset(charset);
+
                 } else {
                     throw new RuntimeException("Unknown charsetIndex:" + charsetIndex);
                 }


### PR DESCRIPTION
* 之前的状态是: 在java中utf8天然支持utf8mb4, 因此在java内部不存在utf8mb4之说，也没有类似的编码；因此cobar和mysql交互之后，最后协商使用utf8, 导致MySQL中的utf8mb4字符没有办法正常处理。

* 为此，将cobar中的charset和dbCharset分离，前者负责java中的字符的编码和解码；后者负责cobar和前端的MySQL Client, 以及后端MySQL对charset的处理。

* server/src/main/server/com/alibaba/cobar/mysql/CharsetUtil.java 只是简单地处理了utf8mb4的情况