### PR TITLE
Connector/J无法在连接字符中使用characterEncoding=utf8m64

### DIFF
--- a/server/src/main/server/com/alibaba/cobar/mysql/bio/MySQLChannel.java
+++ b/server/src/main/server/com/alibaba/cobar/mysql/bio/MySQLChannel.java
@@ -203,7 +203,15 @@ public final class MySQLChannel implements Channel {
     public BinaryPacket execute(RouteResultsetNode rrn, ServerConnection sc, boolean autocommit) throws IOException {
         // 状态一致性检查
         if (this.charsetIndex != sc.getCharsetIndex()) {
-            sendCharset(sc.getCharsetIndex());
+            /*如果后端MySQL服务器配置了character_set_server=utf8mb4,
+            并且数据库客户端要求使用uft8，
+            我们将不发送客户端的字符集要求。
+            这种情况在我们使用mysql官方的Connector/J编程的时候遇见，
+            详细见：http://dev.mysql.com/doc/connector-j/en/connector-j-usagenotes-troubleshooting.html#qandaitem-15-1-15
+                    https://dev.mysql.com/doc/relnotes/connector-j/en/news-5-1-13.html
+            */
+            if(this.charsetIndex != 45 && sc.getCharsetIndex() != 33)
+                sendCharset(sc.getCharsetIndex());
         }
         if (this.txIsolation != sc.getTxIsolation()) {
             sendTxIsolation(sc.getTxIsolation());


### PR DESCRIPTION
当使用mysql官方客户端Connector/J连接，是无法在连接字符中使用characterEncoding=utf8m64的。
他要求mysql服务器配置character_set_server=utf8mb4，以及客户端在连接字符创不指定characterEncoding，
详见https://dev.mysql.com/doc/relnotes/connector-j/en/news-5-1-13.html