### PR TITLE
fix(sec): upgrade org.springframework:spring-context to 5.3.19

### DIFF
--- a/manager/pom.xml
+++ b/manager/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <project.version>1.0.5</project.version>
     <project.build.sourceEncoding>GBK</project.build.sourceEncoding>
-    <spring.version>2.5.6.SEC03</spring.version>
+    <spring.version>5.3.19</spring.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework:spring-context 2.5.6.SEC03
- [CVE-2022-22968](https://www.oscs1024.com/hd/CVE-2022-22968)


### What did I do？
Upgrade org.springframework:spring-context from 2.5.6.SEC03 to 5.3.19 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS